### PR TITLE
Fixes 'knife euca server create' issue

### DIFF
--- a/lib/chef/knife/euca_server_create.rb
+++ b/lib/chef/knife/euca_server_create.rb
@@ -170,8 +170,6 @@ class Chef
 
         print "\n#{ui.color("Waiting for server", :magenta)}"
 
-        display_name = server.dns_name
-
         # wait for it to be ready to do stuff
         server.wait_for { print "."; ready? }
 
@@ -182,7 +180,7 @@ class Chef
 
         print "\n#{ui.color("Waiting for sshd", :magenta)}"
 
-        print(".") until tcp_test_ssh(display_name) {
+        print(".") until tcp_test_ssh(server.dns_name) {
           sleep @initial_sleep_delay ||= 20
           puts("done")
         }


### PR DESCRIPTION
knife euca server create fails for us due to a stale hostname string. This change is the cure for it.
For details, please review the original commit message.
