### PR TITLE
[KNIFE-331] add the ability to pass in --user-data

### DIFF
--- a/lib/chef/knife/euca_server_create.rb
+++ b/lib/chef/knife/euca_server_create.rb
@@ -124,6 +124,12 @@ class Chef
         :boolean => true,
         :default => false
 
+      option :euca_user_data,
+         :long => "--user-data USER_DATA_FILE",
+         :description => "The Eucalyptus User Data file to provision the instance with",
+         :proc => Proc.new { |m| Chef::Config[:knife][:euca_user_data] = m },
+         :default => nil
+
       def tcp_test_ssh(hostname)
         tcp_socket = TCPSocket.new(hostname, 22)
         readable = IO.select([tcp_socket], nil, nil, 5)
@@ -158,6 +164,14 @@ class Chef
           :key_name => Chef::Config[:knife][:euca_ssh_key_id],
           :availability_zone => Chef::Config[:knife][:availability_zone]
         }
+
+        if Chef::Config[:knife][:euca_user_data]
+           begin
+              server_def.merge!(:user_data => File.read(Chef::Config[:knife][:euca_user_data]))
+           rescue
+              ui.warn("Cannot read #{Chef::Config[:knife][:euca_user_data]}: #{$!.inspect}. Ignoring option.")
+           end
+        end
 
         server = connection.servers.create(server_def)
 

--- a/lib/chef/knife/euca_server_create.rb
+++ b/lib/chef/knife/euca_server_create.rb
@@ -166,11 +166,7 @@ class Chef
         }
 
         if Chef::Config[:knife][:euca_user_data]
-           begin
               server_def.merge!(:user_data => File.read(Chef::Config[:knife][:euca_user_data]))
-           rescue
-              ui.warn("Cannot read #{Chef::Config[:knife][:euca_user_data]}: #{$!.inspect}. Ignoring option.")
-           end
         end
 
         server = connection.servers.create(server_def)


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-331

Hi this adds similar functionality to http://tickets.opscode.com/browse/KNIFE_EC2-3 but for Eucalyptus.

It would be great to have all the fog options available via knife.rb and CLI.

I had to remove the short -u, as that conflicts with an option that is already there.
