### PR TITLE
[KNIFE-332] Properly handle bogus "replay attack" failures

### DIFF
--- a/lib/chef/knife/euca_server_create.rb
+++ b/lib/chef/knife/euca_server_create.rb
@@ -174,7 +174,13 @@ class Chef
         print "\n#{ui.color("Waiting for server", :magenta)}"
 
         # wait for it to be ready to do stuff
-        server.wait_for { print "."; ready? }
+        begin
+          server.wait_for { print "."; ready? }
+        rescue Excon::Errors::Forbidden => e
+          print "x"
+          sleep 1
+          retry
+        end
 
         puts("\n")
 

--- a/lib/chef/knife/euca_server_create.rb
+++ b/lib/chef/knife/euca_server_create.rb
@@ -144,6 +144,9 @@ class Chef
       rescue Errno::EHOSTUNREACH
         sleep 2
         false
+      rescue Errno::ENETUNREACH
+        sleep 2
+        false
       ensure
         tcp_socket && tcp_socket.close
       end


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-332

Eucalyptus 2.0.3 has replay attack detection. Sometimes fog trips this with legitimate requests. If we get a 403 waiting for the server, retry the request.

For more on the changes in 2.0.3 see http://open.eucalyptus.com/news/2011-05-25-eucalyptus-203
